### PR TITLE
fixed issue on smaller screens where summary txt

### DIFF
--- a/public/css/materialize.css
+++ b/public/css/materialize.css
@@ -4777,7 +4777,7 @@ small {
 
 .card.small .card-content, .card.medium .card-content, .card.large .card-content {
   max-height: 100%;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .card.small .card-action, .card.medium .card-action, .card.large .card-action {

--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -73,7 +73,7 @@
                             <img  id="<%=el.id%>img" src="<%=el.showImg%>" alt="">
                           </div>
                           <div class="card-stacked">
-                            <div class="card-content">
+                            <div class="card-content card-summary">
                                 <h2 class="header"><%=el.tvShowName%></h2>
                                 <%-el.showSum%>
                             </div>


### PR DESCRIPTION
fixed overflow issue on smaller screens where summary txt could be longer than div space and scrollbar
wasn't appearing